### PR TITLE
update sphinx

### DIFF
--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,19 +1,28 @@
-alabaster==0.7.11         # via sphinx
-babel==2.6.0              # via sphinx
-certifi==2018.8.13        # via requests
-chardet==3.0.4            # via requests
-docutils==0.14            # via sphinx
-idna==2.7                 # via requests
-imagesize==1.0.0          # via sphinx
-jinja2==2.10.1            # via sphinx
-markupsafe==1.0           # via jinja2
-packaging==17.1           # via sphinx
-pygments==2.2.0           # via sphinx
-pyparsing==2.2.0          # via packaging
-pytz==2018.5              # via babel
-requests==2.20.0          # via sphinx
-six==1.11.0               # via packaging, sphinx
-snowballstemmer==1.2.1    # via sphinx
-sphinx==1.7.7
-sphinxcontrib-websupport==1.1.0  # via sphinx
-urllib3==1.24.2             # via requests
+alabaster==0.7.12
+Babel==2.9.0
+certifi==2020.12.5
+chardet==4.0.0
+decorator==4.4.2
+docutils==0.16
+idna==2.10
+imagesize==1.2.0
+Jinja2==2.11.3
+MarkupSafe==1.1.1
+networkx==2.5.1
+packaging==20.9
+pip==21.0.1
+Pygments==2.8.1
+pyparsing==2.4.7
+pytz==2021.1
+requests==2.25.1
+setuptools==52.0.0.post20210125
+snowballstemmer==2.1.0
+Sphinx==3.5.4
+sphinxcontrib-applehelp==1.0.2
+sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-htmlhelp==1.0.3
+sphinxcontrib-jsmath==1.0.1
+sphinxcontrib-qthelp==1.0.3
+sphinxcontrib-serializinghtml==1.1.4
+urllib3==1.26.4
+wheel==0.36.2


### PR DESCRIPTION
Addresses CVE-2021-20270.  Generated docs locally with `sphinx-build` and they looked fine.